### PR TITLE
Add cheat support in http server

### DIFF
--- a/docs/HTTP_CONTROL_SERVER.md
+++ b/docs/HTTP_CONTROL_SERVER.md
@@ -319,3 +319,17 @@ Loads a rom from a parameter specified "path" on the server. Can be initially pa
 Loads the rom at /tmp/rom.gba and pauses the emulator.
 
 ```ok```
+
+# /cheats command
+
+Lists the current cheats and their status
+
+**Example**
+```http://localhost:8080/cheats```
+
+**Result:**
+
+```
+0 - My first cheat: 12345678 AABBCCDD (enabled)
+1 - My second cheat: 12345678 90ABCDEF (disabled)
+```

--- a/docs/HTTP_CONTROL_SERVER.md
+++ b/docs/HTTP_CONTROL_SERVER.md
@@ -333,3 +333,16 @@ Lists the current cheats and their status
 0 - My first cheat: 12345678 AABBCCDD (enabled)
 1 - My second cheat: 12345678 90ABCDEF (disabled)
 ```
+
+# /remove_cheat command
+
+Remove a cheat
+
+**Example**
+```http://localhost:8080/remove_cheat?id=0&id=1```
+
+**Result:**
+
+Removes cheats at index 0 and 1
+
+```ok```

--- a/docs/HTTP_CONTROL_SERVER.md
+++ b/docs/HTTP_CONTROL_SERVER.md
@@ -336,7 +336,7 @@ Lists the current cheats and their status
 
 # /remove_cheat command
 
-Remove a cheat
+Remove one or more cheats
 
 **Example**
 ```http://localhost:8080/remove_cheat?id=0&id=1```
@@ -346,3 +346,18 @@ Remove a cheat
 Removes cheats at index 0 and 1
 
 ```ok```
+
+# /edit_cheat
+
+Edits or adds a cheat. If the `id` field is not specified, it will try to add a cheat on the first available id. There's a guarantee for at least 32 cheat slots.
+All of the fields are optional, but at least one field other than `id` must exist. `enabled` defaults to 1.
+
+**Example**
+```http://localhost:8080/add_cheat?name=My cheat&code=12345678AABBCCDD&id=0&enabled=1```
+
+**Result:**
+
+The following cheat will be added:
+```0 - My cheat: 12345678 AABBCCDD (enabled)```
+
+If a cheat already existed at id 0, because id 0 was specified, the cheat will be overwritten with the new one

--- a/src/main.c
+++ b/src/main.c
@@ -4486,6 +4486,9 @@ uint8_t* se_hcs_callback(const char* cmd, const char** params, uint64_t* result_
       off+=snprintf(buffer+off,sizeof(buffer)-off,"- %s: %f\n",se_keybind_names[i],gui_state.hcs_joypad.inputs[i]);
     }
     str_result = buffer;
+    const char* result=strdup(str_result);
+    *result_size=strlen(result)+1;
+    return (uint8_t*)result;
   }else if(strcmp(cmd,"/save")==0){
     bool okay=false;; 
     while(*params){

--- a/src/main.c
+++ b/src/main.c
@@ -4551,6 +4551,22 @@ uint8_t* se_hcs_callback(const char* cmd, const char** params, uint64_t* result_
       *result_size = actual_size;
       return (uint8_t*)buffer;
     }
+  }else if(strcmp(cmd,"/remove_cheat")==0){
+    bool okay=false;
+    while(*params){
+      if(strcmp(params[0],"id")==0){
+        int id=-1;
+        int result=sscanf(params[1],"%d",&id);
+        if(result!=EOF&&id>=0&&id<SE_NUM_CHEATS){
+          cheats[id].state=-1;
+          okay=true;
+        }else{
+          okay=false;
+        }
+      }
+      params+=2;
+    }
+    str_result=okay? "ok":"failed";
   }
   if(str_result){
     const char * result = strdup(str_result);

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
  *
 **/
 
+#include <stdio.h>
 #define SE_AUDIO_SAMPLE_RATE 48000
 #define SE_AUDIO_BUFF_CHANNELS 2
 #define SE_REBIND_TIMER_LENGTH 5.0
@@ -4566,6 +4567,71 @@ uint8_t* se_hcs_callback(const char* cmd, const char** params, uint64_t* result_
       }
       params+=2;
     }
+    str_result=okay? "ok":"failed";
+  }else if(strcmp(cmd,"/edit_cheat")==0){
+    bool okay=true;
+    int editing_id=-1;
+    bool name_changed=false, code_changed=false, enabled_changed=false;
+    char new_name[SE_MAX_CHEAT_NAME_SIZE+1] = {0};
+    char new_code[SE_MAX_CHEAT_CODE_SIZE+1] = {0};
+    int new_enabled=1;
+    while(*params){
+      if(strcmp(params[0],"id")==0){
+        int result=sscanf(params[1],"%d",&editing_id);
+        if(result==EOF||(editing_id<0||editing_id>=SE_NUM_CHEATS)){
+          okay=false;
+          break;
+        }
+      }else if(strcmp(params[0],"name")==0){
+        name_changed=true;
+        strncpy(new_name,params[1],SE_MAX_CHEAT_NAME_SIZE);
+      }else if(strcmp(params[0],"code")==0){
+        code_changed=true;
+        strncpy(new_code,params[1],SE_MAX_CHEAT_CODE_SIZE);
+      }else if(strcmp(params[0],"enabled")==0){
+        int result=sscanf(params[1],"%d",&new_enabled);
+        if(result==EOF){
+          okay=false;
+          break;
+        }
+        enabled_changed=true;
+      }
+      params+=2;
+    }
+
+    if(okay){
+      // Find an empty slot if an id wasn't specified
+      if(editing_id==-1){
+        okay=false;
+        for(int i=0;i<SE_NUM_CHEATS;++i){
+          if(cheats[i].state==-1){
+            editing_id=i;
+            okay=true;
+            break;
+          }
+        }
+      }
+
+      if(editing_id!=-1){
+        if(!name_changed&&!code_changed&&!enabled_changed){
+          okay=false;
+        }else{
+          if(name_changed){
+            strncpy(cheats[editing_id].name,new_name,SE_MAX_CHEAT_NAME_SIZE);
+          }
+          if(code_changed){
+            se_convert_cheat_code(new_code,editing_id);
+          }
+          if(enabled_changed){
+            cheats[editing_id].state=new_enabled;
+          }
+          if(cheats[editing_id].state==-1){
+            cheats[editing_id].state=1;
+          }
+        }
+      }
+    }
+
     str_result=okay? "ok":"failed";
   }
   if(str_result){

--- a/src/sb_types.h
+++ b/src/sb_types.h
@@ -322,8 +322,10 @@ static void sb_breakup_path(const char* path, const char** base_path, const char
 }
 static void se_join_path(char * dest_path, int dest_size, const char * base_path, const char* file_name, const char* add_extension){
   char * seperator = base_path[0]==0? "" : "/"; 
-  char last_base_char = base_path[strlen(base_path)-1];
-  if(last_base_char=='/'||last_base_char=='\\')seperator="";
+  if(strlen(base_path)!=0){
+    char last_base_char = base_path[strlen(base_path)-1];
+    if(last_base_char=='/'||last_base_char=='\\')seperator="";
+  }
   if(add_extension){
     const char * ext_sep = add_extension[0]=='.' ? "": ".";
     snprintf(dest_path,dest_size,"%s%s%s%s%s",base_path, seperator, file_name,ext_sep,add_extension);


### PR DESCRIPTION
My idea of commands:

`/cheats` to list the cheats
`/add_cheat?name=whatever&code=whatever_in_hex` to add a cheat if possible
`/remove_cheat?id=index_in_array` to remove a cheat. Indexes will be listable by the /cheats command

What do you think?