### PR TITLE
[Frontend] Do not teleport the user to the home dir on folder open error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -4340,9 +4340,10 @@ void se_convert_cheat_code(char * text_code, int cheat_index){
 }
 
 bool se_process_file_browser(){
+  const char *home_dir = sb_get_home_path();
   
   if(gui_state.file_browser.state==SE_FILE_BROWSER_CLOSED)return false; 
-  if(gui_state.file_browser.current_path[0]=='\0')strncpy(gui_state.file_browser.current_path,sb_get_home_path(),SB_FILE_PATH_SIZE);
+  if(gui_state.file_browser.current_path[0]=='\0')strncpy(gui_state.file_browser.current_path,home_dir,SB_FILE_PATH_SIZE);
 
   ImVec2 w_pos={0,0};
   ImVec2 w_size={gui_state.screen_width,gui_state.screen_height};
@@ -4371,6 +4372,11 @@ bool se_process_file_browser(){
       se_file_browser_accept(gui_state.file_browser.current_path);
     }
   }
+
+  if(se_selectable_with_box("Go to home directory",home_dir,ICON_FK_HOME,false,0)){
+    strncpy(gui_state.file_browser.current_path, home_dir, SB_FILE_PATH_SIZE);
+  }
+
   const char* parent_dir = sb_parent_path(gui_state.file_browser.current_path);
   if(se_selectable_with_box("Go to parent directory",parent_dir,ICON_FK_ARROW_UP,false,0)){
     strncpy(gui_state.file_browser.current_path, parent_dir, SB_FILE_PATH_SIZE);

--- a/src/main.c
+++ b/src/main.c
@@ -4342,6 +4342,7 @@ void se_convert_cheat_code(char * text_code, int cheat_index){
 bool se_process_file_browser(){
   
   if(gui_state.file_browser.state==SE_FILE_BROWSER_CLOSED)return false; 
+  if(gui_state.file_browser.current_path[0]=='\0')strncpy(gui_state.file_browser.current_path,sb_get_home_path(),SB_FILE_PATH_SIZE);
 
   ImVec2 w_pos={0,0};
   ImVec2 w_size={gui_state.screen_width,gui_state.screen_height};
@@ -4396,10 +4397,7 @@ bool se_process_file_browser(){
       file_browse->has_cache=false;
     }
     if(tinydir_open(&file_browse->cached_dir, gui_state.file_browser.current_path)==-1){
-      strncpy(gui_state.file_browser.current_path,sb_get_home_path(),SB_FILE_PATH_SIZE);
-      if(tinydir_open(&file_browse->cached_dir, gui_state.file_browser.current_path)==-1){
-        printf("Error opening %s\n",gui_state.file_browser.current_path);
-      }
+      printf("Error opening %s\n",gui_state.file_browser.current_path);
     }else{
       int max_files = 4096;
       file_browse->cached_files= (tinydir_file*)malloc(sizeof(tinydir_file)*max_files);


### PR DESCRIPTION
this is counter-intuitive and super annoying, it now shows nothing, same as file managers when cannot open a folder (maybe a message can be shown in ui, but out of this pr scope)

this way you can just go back to parent folder instead of walking full path again