### PR TITLE
symlink support

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -4485,7 +4485,7 @@ bool se_process_file_browser(){
     file_browse->has_cache=true;
   }
   for(int f = 0;f<file_browse->num_cached_files;++f) {
-    const char *ext = ICON_FK_FOLDER_OPEN;
+    const char *ext = file_browse->cached_files[f].is_link ? ICON_FK_FOLDER_OPEN_O:ICON_FK_FOLDER_OPEN;
     if (!file_browse->cached_files[f].is_dir) {
       const char* base, *file;
       sb_breakup_path(file_browse->cached_files[f].path, &base, &file, &ext);

--- a/src/tinydir.h
+++ b/src/tinydir.h
@@ -96,7 +96,7 @@ extern "C" {
 #define _tinydir_lstat lstat
 #define _tinydir_stat stat
 #else
-#define _tinidyr_lstat stat
+#define _tinydir_lstat stat
 #define _tinydir_stat stat
 #endif
 #endif

--- a/src/tinydir.h
+++ b/src/tinydir.h
@@ -520,7 +520,7 @@ _TINYDIR_FUNC
 int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 {
 	const _tinydir_char_t *filename;
-    int filenameLen;
+	int filenameLen;
 
 	if (dir == NULL || file == NULL)
 	{
@@ -542,7 +542,7 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 #else
 		dir->_e->d_name;
 #endif
-    filenameLen = _tinydir_strlen(filename);
+	filenameLen = _tinydir_strlen(filename);
 
 	if (_tinydir_strlen(dir->path) + filenameLen + 1 + _TINYDIR_PATH_EXTRA >= _TINYDIR_PATH_MAX)
 	{

--- a/src/tinydir.h
+++ b/src/tinydir.h
@@ -516,6 +516,8 @@ _TINYDIR_FUNC
 int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 {
 	const _tinydir_char_t *filename;
+    int filenameLen;
+
 	if (dir == NULL || file == NULL)
 	{
 		errno = EINVAL;
@@ -536,15 +538,15 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 #else
 		dir->_e->d_name;
 #endif
-	if (_tinydir_strlen(dir->path) +
-		_tinydir_strlen(filename) + 1 + _TINYDIR_PATH_EXTRA >=
-		_TINYDIR_PATH_MAX)
+    filenameLen = _tinydir_strlen(filename);
+
+	if (_tinydir_strlen(dir->path) + filenameLen + 1 + _TINYDIR_PATH_EXTRA >= _TINYDIR_PATH_MAX)
 	{
 		/* the path for the file will be too long */
 		errno = ENAMETOOLONG;
 		return -1;
 	}
-	if (_tinydir_strlen(filename) >= _TINYDIR_FILENAME_MAX)
+	if (filenameLen >= _TINYDIR_FILENAME_MAX)
 	{
 		errno = ENAMETOOLONG;
 		return -1;

--- a/src/tinydir.h
+++ b/src/tinydir.h
@@ -86,6 +86,18 @@ extern "C" {
 # define _tinydir_strncmp strncmp
 #endif
 
+#ifndef _MSC_VER
+#ifdef __MINGW32__
+#define _tinydir_lstat _tstat
+#elif defined _BSD_SOURCE || defined _DEFAULT_SOURCE || defined BSD || \
+	(defined _XOPEN_SOURCE && _XOPEN_SOURCE >= 500) || (defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 200112L) || \
+	(defined __APPLE__ && defined __MACH__)
+#define _tinydir_lstat lstat
+#else
+#define _tinidyr_lstat stat
+#endif
+#endif
+
 #if (defined _MSC_VER || defined __MINGW32__)
 # include <windows.h>
 # define _TINYDIR_PATH_MAX MAX_PATH
@@ -544,21 +556,8 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 	_tinydir_strcpy(file->name, filename);
 	_tinydir_strcat(file->path, filename);
 #ifndef _MSC_VER
-#ifdef __MINGW32__
-	if (_tstat(
-#elif (defined _BSD_SOURCE) || (defined _DEFAULT_SOURCE)	\
-	|| ((defined _XOPEN_SOURCE) && (_XOPEN_SOURCE >= 500))	\
-	|| ((defined _POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L)) \
-	|| ((defined __APPLE__) && (defined __MACH__)) \
-	|| (defined BSD)
-	if (lstat(
-#else
-	if (stat(
-#endif
-		file->path, &file->_s) == -1)
-	{
+	if (_tinydir_lstat(file->path, &file->_s) == -1)
 		return -1;
-	}
 #endif
 	_tinydir_get_ext(file);
 


### PR DESCRIPTION
since i want to be able to distinguish between standard folder and link, i'm using the `-o` variant of the icon

here, it is clear that bin and lib are links
![Screenshot_20230928_104554](https://github.com/skylersaleh/SkyEmu/assets/3252255/c010db05-f4fa-47b0-b7ee-354d1c972911)

i don't know how to test the _MSC_VER path, because, on windows, the os file manager is called, so no file browser issue will ever arise there and all the work here does not touch that

in theory should work as before but get the new icon, in whatever case that path is called

closes #334