### PR TITLE
Add 'fullscreen' option in the launch arguments.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -8822,6 +8822,8 @@ sapp_desc sokol_main(int argc, char* argv[]) {
   emu_state.cmd_line_args =argv;
   int width = 1280;
   int height = 800;
+  int request_fullscreen = sapp_is_fullscreen() ? true : false;
+
   if(argc>2&&strcmp("run_gb_test",argv[1])==0){
     gui_state.test_runner_mode=true;
     emu_state.cmd_line_arg_count =argc-1;
@@ -8835,7 +8837,13 @@ sapp_desc sokol_main(int argc, char* argv[]) {
     emu_state.cmd_line_args =argv+1;
     width = GBA_LCD_W;
     height= GBA_LCD_H;
-  } 
+  }
+  if(argc>1 && strcmp("fullscreen",emu_state.cmd_line_args[1])==0)
+  {
+    request_fullscreen = true;
+    emu_state.cmd_line_arg_count =argc-1;
+    emu_state.cmd_line_args =argv+1;
+  }
   if(emu_state.cmd_line_arg_count >3&&strcmp("http_server",emu_state.cmd_line_args[1])==0)headless_mode();
 
   #ifdef SE_PLATFORM_IOS
@@ -8854,6 +8862,7 @@ sapp_desc sokol_main(int argc, char* argv[]) {
       .enable_clipboard =true,
       .high_dpi = true,
       .max_dropped_file_path_length = 8192,
+      .fullscreen = request_fullscreen,
 #if defined(EMSCRIPTEN)
       .max_dropped_files=32,
 #endif


### PR DESCRIPTION
This is an update to allow setting the view mode to full screen, when launching via the terminal. 

Tested against Windows, with and without rom path included. Launch behavior same when argument not provided.

Testing:
```
cd "{buildDir}"
.\SkyEmu.exe fullscreen
.\SkyEmu.exe fullscreen "{romPath}"
```