### PR TITLE
ci: add Linux aarch64 and webOS builds for the libretro core

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,6 +118,15 @@ libretro-build-linux-x64:
     - .core-defs-linux
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:backports
 
+# Linux aarch64
+# No image override here: the :backports tag only exists for the amd64 image,
+# and the aarch64 one ships gcc-12 in its main Dockerfile, so the gcc-12 that
+# .core-defs-linux asks for is already present.
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-cmake-aarch64
+    - .core-defs-linux
+
 # Linux 32-bit
 libretro-build-linux-i686:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,11 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-cmake.yml'
 
+  #################################### MISC ##################################
+  # webOS (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-cmake.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -190,3 +195,10 @@ libretro-build-tvos-arm64:
   extends:
     - .libretro-tvos-cmake-arm64
     - .core-defs-ios-arm64
+
+#################################### MISC ####################################
+# webOS 32-bit (LGTV)
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-cmake
+    - .core-defs


### PR DESCRIPTION
Two targets the libretro buildbot does not currently build for SkyEmu.

**Linux aarch64** mirrors the x64 job. It carries no image override: the `:backports` tag exists only for the amd64 image, while the aarch64 one already ships the gcc-12 that `.core-defs-linux` asks for, in its main Dockerfile.

**webOS (LG TV)** uses the `webos-cmake` template as-is — `RETRO_CORE_ONLY=ON` is all it needs, nothing platform-specific. Verified by replaying the job against the same buildroot SDK the build image bakes in: it produces `skyemu_libretro.so`, `ELF 32-bit LSB shared object, ARM, EABI5`.